### PR TITLE
Added touch position conversion; Documentation fixes

### DIFF
--- a/delay.h
+++ b/delay.h
@@ -1,9 +1,12 @@
 #ifndef DELAY_H_
 #define DELAY_H_
 
-#include <stdint.h>
-#include "tm4c1294ncpdt.h"
+/*- Header files ------------------------------------------------------------*/
+#include <stdint.h>                             /* C Standard integers       */
+#include "tm4c1294ncpdt.h"                      /* TivaWare library          */
 
+
+/*- Prototypes --------------------------------------------------------------*/
 void vDelayInit(void);
 void vDelay_us(uint16_t uiTenthMillis);
 void vDelay_ms(uint16_t uiMilliseconds);

--- a/display.c
+++ b/display.c
@@ -225,7 +225,7 @@ void vDisplayClear(void)
 
     vDisplayWindowSet(0,480-1,0,272-1);
     vDisplayStartPixelWrite();
-    for (ulCounter = 0; ulCounter < (479*271); ++ulCounter)
+    for (ulCounter = 0; ulCounter < (480*272); ++ulCounter)
     {
     	vDisplayPixelWrite(0x00, 0x00, 0x00);
     }

--- a/display.c
+++ b/display.c
@@ -1,34 +1,48 @@
-/*- Headerdateien -----------------------------------------------------------*/
+/*- Headerfiles -------------------------------------------------------------*/
 #include "display.h"
 #include "delay.h"
 
 
-/*- Modulglobale Funktionsprototypen ----------------------------------------*/
+/*- Local Prototypes --------------------------------------------------------*/
 static void vDisplayInitGPIO(void);
 
 static void vDisplaySendCmd(uint8_t ucCommand);
 static void vDisplaySendData(uint8_t ucData);
 
+
+/**
+ *  @brief  Configure GPIO for Display-Interface
+ *
+ *  PORTL: Control lines
+ *  PORTM: Data lines (parallel interface)
+ *                                                                           */
 void vDisplayInitGPIO(void)
 {
-    /* GPIO Sysclock                */
+    /* GPIO Clock                                                            */
     SYSCTL_RCGCGPIO_R |= (1 << 10) | (1 << 11);     /* PORTL, PORTM          */
-    asm("\tnop\r\n\tnop\r\n\tnop\r\n");             /* Lock time             */
+    asm("\tnop\r\n\tnop\r\n\tnop\r\n");             /* Lock time > 3 Cycles  */
 
-    /* Enable digital function      */
+    /* Enable digital function                                               */
     DISPLAY_CTL_DEN = 0x1F;
     DISPLAY_DATA_DEN = 0xFF;
 
-    /* Setup Data direction         */
+    /* Setup Data direction                                                  */
     DISPLAY_CTL_DIR = 0x1F;                         /* All Output            */
     DISPLAY_DATA_DIR = 0xFF;                        /* All Output            */
 
-    /* Initial values               */
+    /* Initial values                                                        */
     DISPLAY_CTL_PORT = 0x1F;
     DISPLAY_DATA_PORT = 0x00;
 }
 
-
+/**
+ *  @brief  Send command byte to display
+ *
+ *  Reference    [Pnr,  Pro,  Snd 9/13,  Pro8/2017]  "Projektaufgabe:  Digitales
+ *  Speicheroszilloskop",  Section A.2.1
+ *
+ *  @param[in]  ucCommand   Display command byte as per Datasheet
+ *                                                                           */
 void vDisplaySendCmd(uint8_t ucCommand)
 {
     DISPLAY_CTL_PORT = 0x1F;        /* Initial state                         */
@@ -43,7 +57,14 @@ void vDisplaySendCmd(uint8_t ucCommand)
     DISPLAY_CTL_PORT |= 1 << DISPLAY_CTL_PIN_CS;    /* Disable chip select   */
 }
 
-
+/**
+ *  @brief  Send data byte to display
+ *
+ *  Reference   [Pnr,  Pro,  Snd 9/13,  Pro8/2017]  "Projektaufgabe:  Digitales
+ *  Speicheroszilloskop",  Section A.2.2
+ *
+ *  @param[in]  ucData  Display data byte
+ *                                                                           */
 void vDisplaySendData(uint8_t ucData)
 {
     DISPLAY_CTL_PORT = 0x1F;        /* Initial state                         */
@@ -58,7 +79,12 @@ void vDisplaySendData(uint8_t ucData)
     DISPLAY_CTL_PORT |= 1 << DISPLAY_CTL_PIN_CS;    /* Disable chip select   */
 }
 
-
+/**
+ *  @brief  Initialise display controller for TFT panel used in the lab.
+ *
+ *  Reference   [Pnr,  Pro,  Snd 9/13,  Pro8/2017]  "Projektaufgabe:  Digitales
+ *  Speicheroszilloskop",  Section A.3
+ *                                                                           */
 void vDisplayInit(void)
 {
     vDisplayInitGPIO();             /* Setup GPIO registers                  */
@@ -134,15 +160,22 @@ void vDisplayInit(void)
     vDisplaySendCmd(DISPLAY_CMD_DISPON);
 }
 
-
+/**
+ *  @brief  Set display window for next pixel block
+ *
+ *  Reference  [Pnr,  Pro,  Snd 9/13,  Pro8/2017]  "Projektaufgabe:  Digitales
+ *  Speicheroszilloskop",  Section A.4
+ */
 void vDisplayWindowSet(uint16_t uiColStart, uint16_t uiColEnd, uint16_t uiRowStart, uint16_t uiRowEnd)
 {
+    /* Set page number (X direction)                                         */
     vDisplaySendCmd(DISPLAY_CMD_SETPAGE);
     vDisplaySendData(uiColStart >> 8);
     vDisplaySendData(uiColStart & 0xFF);
     vDisplaySendData(uiColEnd >> 8);
     vDisplaySendData(uiColEnd & 0xFF);
 
+    /* Set column number (Y direction)                                       */
     vDisplaySendCmd(DISPLAY_CMD_SETCOL);
     vDisplaySendData(uiRowStart >> 8);
     vDisplaySendData(uiRowStart & 0xFF);
@@ -150,13 +183,30 @@ void vDisplayWindowSet(uint16_t uiColStart, uint16_t uiColEnd, uint16_t uiRowSta
     vDisplaySendData(uiRowEnd & 0xFF);
 }
 
-
+/**
+ *  @brief  Begin pixel block
+ *
+ *  Reference  [Pnr,  Pro,  Snd 9/13,  Pro8/2017]  "Projektaufgabe:  Digitales
+ *  Speicheroszilloskop",  Section A.5
+ *                                                                           */
 void vDisplayStartPixelWrite(void)
 {
     vDisplaySendCmd(DISPLAY_CMD_WRITEPX);
 }
 
-
+/**
+ *  @brief  Write single pixel data
+ *
+ *  Reference  [Pnr,  Pro,  Snd 9/13,  Pro8/2017]  "Projektaufgabe:  Digitales
+ *  Speicheroszilloskop",  Section A.5
+ *
+ *  @note   vDisplayStartPixelWrite  is required  prior to first  call to this
+ *          function.
+ *
+ *  @param[in]  ucRed   Red color component
+ *  @param[in]  ucGreen Green color component
+ *  @param[in]  ucBlue  Blue color component
+ *                                                                           */
 void vDisplayPixelWrite(uint8_t ucRed, uint8_t ucGreen, uint8_t ucBlue)
 {
     vDisplaySendData(ucRed);
@@ -164,7 +214,11 @@ void vDisplayPixelWrite(uint8_t ucRed, uint8_t ucGreen, uint8_t ucBlue)
     vDisplaySendData(ucBlue);
 }
 
-
+/**
+ *  @brief  Clear display (overwrite entire area with black pixels)
+ *
+ *  @todo   Move this function to the "Graphics" module
+ *                                                                           */
 void vDisplayClear(void)
 {
 	uint32_t ulCounter;

--- a/display.h
+++ b/display.h
@@ -1,12 +1,12 @@
 #ifndef DISPLAY_H_
 #define DISPLAY_H_
 
-/*- Headerdateien -----------------------------------------------------------*/
+/*- Header files ------------------------------------------------------------*/
 #include <stdint.h>                             /* C Standard Integer Typen  */
-#include "tm4c1294ncpdt.h"                      /* TiveWare Driver Library   */
+#include "tm4c1294ncpdt.h"                      /* TivaWare Library          */
 
 
-/*- Konstantendefinitionen --------------------------------------------------*/
+/*- Defines -----------------------------------------------------------------*/
 #define DISPLAY_SIZE_X      480                 /* Display Breite in px      */
 #define DISPLAY_SIZE_Y      272                 /* Display Höhe in pc        */
 
@@ -38,7 +38,7 @@
 #define DISPLAY_CMD_WRITEPX     0x2C            /* Write pixel               */
 
 
-/*- Funktionsprototypen -----------------------------------------------------*/
+/*- Prototypes -------------------------------------------------------------*/
 void vDisplayInit(void);
 void vDisplayWindowSet(uint16_t uiColStart, uint16_t uiColEnd, uint16_t uiRowStart, uint16_t uiRowEnd);
 void vDisplayStartPixelWrite(void);

--- a/main.c
+++ b/main.c
@@ -10,7 +10,8 @@
 int main(void)
 {
     uint16_t uiCounter;
-    tsTouchData sTouchData;
+    //tsTouchData sTouchData;
+    tsTouchPos sTouchPos;
 
     /* System clock configuration                                            */
     /* Reference  [Rms]  "Serielle  Kommunikation  RS-232+UART  ARM Cortex M4 /
@@ -39,10 +40,16 @@ int main(void)
 
     while(1)
     {
-        sTouchData = sGetTouchData();
+        //sTouchData = sGetTouchData();
+    	sTouchPos = sGetTouchPos();
 
-        printf("Pos X:%3d, Y:%3d\r\n", sTouchData.uiX, sTouchData.uiY);
+        //printf("Data X: %4d, Y: %4d\tPos X:%3d, Y:%3d\r\n", sTouchData.uiX, sTouchData.uiY, sTouchPos.iX, sTouchPos.iY);
 
-        vDelay_ms(1000);
+        if (sTouchPos.iX != -1)
+        {
+        	vDisplayWindowSet(sTouchPos.iX, sTouchPos.iX, sTouchPos.iY, sTouchPos.iY);
+        	vDisplayStartPixelWrite();
+        	vDisplayPixelWrite(0xFF, 0xFF, 0xFF);
+        }
     }
 }

--- a/main.c
+++ b/main.c
@@ -1,40 +1,35 @@
-#include "display.h"
-#include "touch.h"
-#include "delay.h"
-#include "mpp1.h"
-#include <stdio.h>
+/*- Header files ------------------------------------------------------------*/
+#include <stdio.h>                  /* Libc Standard IO                      */
+#include "display.h"                /* Display module                        */
+#include "touch.h"                  /* Touch Controller module               */
+#include "delay.h"                  /* Delay timer module                    */
 
 /**
- * main.c
- */
+ *  @brief  Hauptprogramm
+ *                                                                           */
 int main(void)
 {
     uint16_t uiCounter;
-    tsTouchPos sTouchPos;
+    tsTouchData sTouchData;
 
+    /* System clock configuration                                            */
+    /* Reference  [Rms]  "Serielle  Kommunikation  RS-232+UART  ARM Cortex M4 /
+     * TM4C1294", p. 62                                                      */
     SYSCTL_MOSCCTL_R &= ~(SYSCTL_MOSCCTL_OSCRNG | SYSCTL_MOSCCTL_PWRDN | SYSCTL_MOSCCTL_NOXTAL);
     SYSCTL_MOSCCTL_R |= SYSCTL_MOSCCTL_OSCRNG;
     SYSCTL_RSCLKCFG_R = SYSCTL_RSCLKCFG_OSCSRC_MOSC;
 
+    /* -- Todo: PLL auf 120MHz -- */
+
+    /* Init peripherals                                                      */
     vDelayInit();
+    vDisplayInit();
+    vTouchInit();
 
-    /*SYSCTL_RCGCGPIO_R |= SYSCTL_RCGCGPIO_R11;
-    asm("\tnop\r\n\tnop\r\n\tnop\r\n");
-
-    GPIO_PORTM_DEN_R |= 1 << 0;
-    GPIO_PORTM_DIR_R |= 1 << 0;
-    GPIO_PORTM_DATA_R |= 1 << 0;
-
-    while(1)
-    {
-        vDelay_us(100);
-        GPIO_PORTM_DATA_R ^= (1 << 0);
-    }*/
-
-    /*vDisplayInit();
-
+    /* Clear any previous display data                                       */
     vDisplayClear();
 
+    /* Main application                                                      */
     vDisplayWindowSet(240, 247, 136, 136);
     vDisplayStartPixelWrite();
     for (uiCounter = 0; uiCounter < 8; ++uiCounter)
@@ -44,18 +39,9 @@ int main(void)
 
     while(1)
     {
-        ;
-    }*/
+        sTouchData = sGetTouchData();
 
-    vTouchInit();
-
-
-    while(1)
-    {
-        sTouchPos = sGetTouchPos();
-        uiCounter = bIsTouchPenDown();
-
-        printf("Pen: %d. Pos X:%3d, Y:%3d\r\n", uiCounter, sTouchPos.uiX, sTouchPos.uiY);
+        printf("Pos X:%3d, Y:%3d\r\n", sTouchData.uiX, sTouchData.uiY);
 
         vDelay_ms(1000);
     }

--- a/touch.c
+++ b/touch.c
@@ -4,7 +4,7 @@
 
 /*- Calibration values ------------------------------------------------------*/
 #define TOUCH_CAL_MIN_X 158         /* Minimum X raw value                   */
-#define TOUCH_CAL_MAX_X 3028        /* Maximum X raw value                   */
+#define TOUCH_CAL_MAX_X 3928        /* Maximum X raw value                   */
 #define TOUCH_CAL_MIN_Y 271         /* Minimum Y raw value                   */
 #define TOUCH_CAL_MAX_Y 3715        /* Maximum Y raw value                   */
 

--- a/touch.c
+++ b/touch.c
@@ -112,8 +112,8 @@ uint16_t uiTouchReceive(void)
  *                                                                           */
 static bool bIsTouchDataValid(tsTouchData sTouchData)       /* inline? */
 {
-    return (sTouchData.uiX > TOUCH_CAL_MIN_X && sTouchData.uiX < TOUCH_CAL_MAX_X) &&
-           (sTouchData.uiY > TOUCH_CAL_MIN_Y && sTouchData.uiY > TOUCH_CAL_MAX_Y);
+    return (sTouchData.uiX > TOUCH_CAL_MIN_X) && (sTouchData.uiX < TOUCH_CAL_MAX_X) &&
+           (sTouchData.uiY > TOUCH_CAL_MIN_Y) && (sTouchData.uiY < TOUCH_CAL_MAX_Y);
 }
 
 /**

--- a/touch.h
+++ b/touch.h
@@ -1,10 +1,10 @@
 #ifndef TOUCH_H_
 #define TOUCH_H_
 
-/*- Headerdateien -----------------------------------------------------------*/
-#include <stdint.h>
-#include <stdbool.h>
-#include "tm4c1294ncpdt.h"
+/*- Header files ------------------------------------------------------------*/
+#include <stdint.h>                 /* C Standard integer                    */
+#include <stdbool.h>                /* C Standard boolean                    */
+#include "tm4c1294ncpdt.h"          /* TivaWare Library                      */
 
 
 /*- Konstantendefinitionen --------------------------------------------------*/
@@ -20,16 +20,36 @@
 #define TOUCH_CMD_XPOS          0xD0        /* Read X Position command       */
 #define TOUCH_CMD_YPOS          0x90        /* Read Y Position command       */
 
+#define TOUCH_POS_INVALID       (tsTouchPos){-1,-1}     /* Position invalid  */
 
-/*- Typdefinitionen ---------------------------------------------------------*/
-typedef struct tag_tsTouchPos {
+
+/*- Type definitions --------------------------------------------------------*/
+/**
+ *  @struct tsTouchData
+ *  @brief  Touch-Rohdaten
+ *                                                                           */
+typedef struct __attribute__((packed)) tag_tsTouchData {
+    /*! @brief  X-Rohwert                                                    */
     uint16_t uiX;
+    /*! @brief  Y-Rohwert                                                    */
     uint16_t uiY;
+} tsTouchData;
+
+/**
+ *  @struct tsTouchPos
+ *  @brief  Touch-Position als Displaykoordinaten
+ *                                                                           */
+typedef struct __attribute__((packed)) tag_tsTouchPos {
+    /*! @brief  X-Position (vom linken Rand aus)                             */
+    int16_t iX;
+    /*! @brief  Y-Position (vom oberen Rand aus)                             */
+    int16_t iY;
 } tsTouchPos;
 
-/*- Funktionsprototypen -----------------------------------------------------*/
+
+/*- Prototypes --------------------------------------------------------------*/
 void vTouchInit(void);
+tsTouchData sGetTouchData(void);
 tsTouchPos sGetTouchPos(void);
-bool bIsTouchPenDown(void);
 
 #endif /* TOUCH_H_ */


### PR DESCRIPTION
This PR contains the following modifications:
- expand the Touch module by adding functions to convert raw sensor data (12 Bit values) to screen coordinates (X/Y)
- fix documentation, add doxygen headers
- improve/fix the demo application

**Note regarding touch position conversion**
Position conversion to X/Y-coordinates is currently using float math functions. If possible, these should be replaced by integer math functions for improved performance.