### PR TITLE
Adds system config module; Raises SysClk to 120MHz using PLL

### DIFF
--- a/delay.c
+++ b/delay.c
@@ -75,9 +75,15 @@ void vDelay_ms(uint16_t uiMilliseconds)
     /* Configure Timer match register to trigger at "0"                      */
     TIMER0_TAMATCHR_R = 0;
 
+#if SYSCLK_25MHz
     /* Timer configuration for f_Sys = 25MHz                                 */
     TIMER0_TAILR_R = 100;
     TIMER0_TAPR_R = 250;
+#else
+    /* Timer configuration for f_sys = 120MHz                                */
+    TIMER0_TAILR_R = 1000;
+    TIMER0_TAPR_R = 120;
+#endif
 
     /* Clear Timer interrupt                                                 */
     TIMER0_ICR_R |= TIMER_ICR_TATOCINT;

--- a/main.c
+++ b/main.c
@@ -3,6 +3,7 @@
 #include "display.h"                /* Display module                        */
 #include "touch.h"                  /* Touch Controller module               */
 #include "delay.h"                  /* Delay timer module                    */
+#include "system.h"                 /* System configuration module           */
 
 /**
  *  @brief  Hauptprogramm
@@ -13,14 +14,8 @@ int main(void)
     //tsTouchData sTouchData;
     tsTouchPos sTouchPos;
 
-    /* System clock configuration                                            */
-    /* Reference  [Rms]  "Serielle  Kommunikation  RS-232+UART  ARM Cortex M4 /
-     * TM4C1294", p. 62                                                      */
-    SYSCTL_MOSCCTL_R &= ~(SYSCTL_MOSCCTL_OSCRNG | SYSCTL_MOSCCTL_PWRDN | SYSCTL_MOSCCTL_NOXTAL);
-    SYSCTL_MOSCCTL_R |= SYSCTL_MOSCCTL_OSCRNG;
-    SYSCTL_RSCLKCFG_R = SYSCTL_RSCLKCFG_OSCSRC_MOSC;
-
-    /* -- Todo: PLL auf 120MHz -- */
+    /* Configure MOSC and PLL for 120MHz SysClk                              */
+    vSystemClkInit();
 
     /* Init peripherals                                                      */
     vDelayInit();

--- a/system.h
+++ b/system.h
@@ -1,0 +1,21 @@
+#ifndef SYSTEM_H_
+#define SYSTEM_H_
+
+/*- Header files ------------------------------------------------------------*/
+#include <stdint.h>                 /* LibC Standard Integer                 */
+#include "driverlib/sysctl.h"       /* TivaWare SysCtl Library               */
+
+
+/*- Inline functions --------------------------------------------------------*/
+static inline void vSystemClkInit(void)
+{
+    /* Configure System clock                                                */
+    /* - Use 25MHz external main oscillator
+     * - Use PLL with f_vco=480MHz
+     * - SysClk = 120MHz
+     *
+     * Reference [SPMU298D] Section 26.2.2.2                                 */
+    SysCtlClockFreqSet(SYSCTL_XTAL_25MHZ | SYSCTL_OSC_MAIN | SYSCTL_USE_PLL | SYSCTL_CFG_VCO_480, 120000000);
+}
+
+#endif /* SYSTEM_H_ */


### PR DESCRIPTION
This PR contains the following modifications:
- System configuration moved into separate module
- SysClk raised to 120MHz using 25MHz MOSC
- Adjusted display delay timer configuration for 120MHz clock

**Note regarding the system config module**
PLL configuration is currently using the TivaWare library. Future optimisation should replace library functions with direct register access.