### PR TITLE
Adds ADC and Sampler modules

### DIFF
--- a/IVT.patch
+++ b/IVT.patch
@@ -1,0 +1,7 @@
+36a37,38
+> extern void __attribute__((interrupt)) vISR_AdcVinSequencer(void); /* see sampler.c                     */
+> 
+100c102
+<     IntDefaultHandler,                      // ADC Sequence 0
+---
+>     vISR_AdcVinSequencer,                   // ADC Sequence 0

--- a/adc.c
+++ b/adc.c
@@ -1,0 +1,121 @@
+/*- Header files ------------------------------------------------------------*/
+#include <stdbool.h>                /* Libc Standard boolean                 */
+#include <stdint.h>                 /* Libc Standard integer                 */
+#include "tm4c1294ncpdt.h"          /* TivaWare Hardware Register Map        */
+#include "inc/hw_memmap.h"          /* TivaWare Hardware Memory Map          */
+#include "driverlib/gpio.h"         /* TivaWare GPIO DriverLib               */
+#include "driverlib/pin_map.h"      /* TivaWare GPIO Pin Mappings            */
+#include "driverlib/adc.h"          /* TivaWare ADC DriverLib                */
+#include "driverlib/sysctl.h"       /* TivaWare SysCtl DriverLib             */
+#include "adc.h"
+
+
+/*- Local Prototypes --------------------------------------------------------*/
+static uint16_t uiGetAdcSampleVtemp(void);
+
+
+/**
+ *  @brief  Initialise ADC module and analog inputs on GPIO
+ *
+ *  Initialise GPIO registers for PORTE, configure PE0 and PE1 as analog in-
+ *  puts.
+ *
+ *  Sequencer 0: sampling PE0 (V_in), triggered by Timer (deferred setup)
+ *  Sequencer 1: sampling PE1 (V_trig), triggered by software
+ *  Sequencer 2: sampling Temperature, triggered continuously when idle
+ *                                                                           */
+void vAdcInit(void)
+{
+    /* Reference [TM4C1294NCPDT Datasheet] Section 15.4.1                    */
+    /* Enable clock to GPIO PORTE                                            */
+    SYSCTL_RCGCGPIO_R |= ADC_PORT_RCGC;
+    /* Enable clock to ADC0 peripheral                                       */
+    SYSCTL_RCGCADC_R |= SYSCTL_RCGCADC_R0;
+    asm("\tnop;\r\n\tnop;\r\n\tnop;");
+
+    /* Configure PE0 (V_in) and PE1 (V_trig) as analog inputs                */
+    //GPIOPadConfigSet(GPIO_PORTE_BASE, GPIO_PIN_0 | GPIO_PIN_1, GPIO_STRENGTH_2MA, GPIO_PIN_TYPE_ANALOG);
+    GPIOPinTypeADC(GPIO_PORTE_BASE, GPIO_PIN_0 | GPIO_PIN_1);
+
+    /* Configure ADC sample clock source                                     */
+    /* Sample clock frequency: f_ADC = f_PLL / 24 = 480MHz / 24 = 20MHz      */
+    ADCClockConfigSet(ADC0_BASE, ADC_CLOCK_SRC_PLL | ADC_CLOCK_RATE_FULL, 24);
+
+    /* Configure ADC internal voltage reference to use internal 3.3V Ref.    */
+    ADCReferenceSet(ADC0_BASE, ADC_REF_INT);
+
+    /* Disable all ADC sequencers for configuration                          */
+    ADCSequenceDisable(ADC0_BASE, ADC_SEQ_VIN);
+    ADCSequenceDisable(ADC0_BASE, ADC_SEQ_VTRIG);
+    ADCSequenceDisable(ADC0_BASE, ADC_SEQ_TEMP);
+    ADCSequenceDisable(ADC0_BASE, 3);
+
+    /* Configure ADC Sequencer 0 for V_in (PE0, AIN3) sampling               */
+    /* Sample started by processor in default configuration!                 *
+     * Reconfigured to use Timer by Sampler module                           */
+    ADCSequenceConfigure(ADC0_BASE, ADC_SEQ_VIN, ADC_TRIGGER_PROCESSOR, 0);
+    ADCSequenceStepConfigure(ADC0_BASE, ADC_SEQ_VIN, 0, ADC_CTL_CH3 | ADC_CTL_IE | ADC_CTL_END);
+
+    /* Configure ADC Sequencer 1 for V_trig (PE1, AIN2) sampling             */
+    ADCSequenceConfigure(ADC0_BASE, ADC_SEQ_VTRIG, ADC_TRIGGER_PROCESSOR, 1);
+    ADCSequenceStepConfigure(ADC0_BASE, ADC_SEQ_VTRIG, 0, ADC_CTL_CH2 | ADC_CTL_END);
+
+    /* Configure ADC Sequencer 2 for Temperature sampling                    */
+    /* Sampled continuously by default. Lowest priority                      */
+    ADCSequenceConfigure(ADC0_BASE, ADC_SEQ_TEMP, ADC_TRIGGER_ALWAYS, 2);
+    ADCSequenceStepConfigure(ADC0_BASE, ADC_SEQ_TEMP, 0, ADC_CTL_TS | ADC_CTL_END);
+
+    /* Enable Sequencers                                                     */
+    ADCSequenceEnable(ADC0_BASE, ADC_SEQ_VIN);
+    ADCSequenceEnable(ADC0_BASE, ADC_SEQ_VTRIG);
+    ADCSequenceEnable(ADC0_BASE, ADC_SEQ_TEMP);
+}
+
+/**
+ *  @brief  Read ADC value for V_trig
+ *
+ *  Will busy-wait until sample is complete and stored in FIFO.
+ *
+ *  @return uint16_t    ADC value (12 bit resolution)
+ *                                                                           */
+uint16_t uiGetAdcSampleVtrig(void)
+{
+    /* Trigger Vtrig Sequencer sampling                                      */
+    ADCProcessorTrigger(ADC0_BASE, ADC_SEQ_VTRIG | ADC_TRIGGER_SIGNAL);
+
+    /* Wait for sample ready                                                 */
+    while(ADC0_SSFSTAT1_R & ADC_SSFSTAT1_EMPTY);
+
+    /* Read sample from FIFO                                                 */
+    return ADC0_SSFIFO1_R;
+}
+
+/**
+ *  @brief  Read ADC value for chip die temperature
+ *
+ *  Will busy-wait until sample is complete and stored in FIFO.
+ *
+ *  @return uint16_t    ADC value (12 bit resolution)
+ *                                                                           */
+uint16_t uiGetAdcSampleVtemp(void)
+{
+    /* Wait for sample ready                                                 */
+    while(ADC0_SSFSTAT2_R & ADC_SSFSTAT2_EMPTY);
+
+    /* Read sample from FIFO                                                 */
+    return ADC0_SSFIFO2_R;
+}
+
+/**
+ *  @brief  Read chip die temp value and convert to °C
+ *
+ *  @return int16_t     Chip die temperature in °C
+ *                                                                           */
+int16_t iGetAdcChipTemperature(void)
+{
+    register uint16_t uiTemperatureValue = uiGetAdcSampleVtemp();
+
+    /* Convert ADC value to temperature                                      */
+    /* Reference [TM4C1294NCPDT Datasheet] Section 15.3.6                    */
+    return 147.5 - ((75 * (ADC_VREFP - ADC_VREFN) * uiTemperatureValue) / 4096);
+}

--- a/adc.h
+++ b/adc.h
@@ -1,0 +1,29 @@
+#ifndef ADC_H_
+#define ADC_H_
+
+/*- Header files ------------------------------------------------------------*/
+#include <stdint.h>                 /* Libc Standard integer                 */
+
+
+/*- Defines -----------------------------------------------------------------*/
+#define ADC_PORT_RCGC   SYSCTL_RCGCGPIO_R4      /* RCGC Index for GPIO       */
+#if NO_USE_TIVA
+#define ADC_PORT_AFSEL  GPIO_PORTE_AHB_AFSEL_R  /* GPIO AFSEL Register       */
+#define ADC_PORT_AMSEL  GPIO_PORTE_AHB_AMSEL_R  /* GPIO AMSEL Register       */
+#define ADC_PORT_DEN    GPIO_PORTE_AHB_DEN_R    /* GPIO DigEnable Register   */
+#define ADC_PORT_DIR    GPIO_PORTE_AHB_DIR_R    /* GPIO Direction Register   */
+#endif
+
+#define ADC_VREFP       3.3F                    /* Positive voltage ref.     */
+#define ADC_VREFN       0.0F                    /* Negative voltage ref.     */
+
+#define ADC_SEQ_VIN     0                       /* Sequencer used for V_in   */
+#define ADC_SEQ_VTRIG   1                       /* Sequencer used for V_trig */
+#define ADC_SEQ_TEMP    2                       /* Sequencer used for Tempe. */
+
+/*- Prototoypes -------------------------------------------------------------*/
+void vAdcInit(void);
+uint16_t uiGetAdcSampleVtrig(void);
+int16_t iGetAdcChipTemperature(void);
+
+#endif /* ADC_H_ */

--- a/doc_markup.h
+++ b/doc_markup.h
@@ -1,0 +1,13 @@
+#ifndef DOC_MARKUP_H_
+#define DOC_MARKUP_H_
+
+/*- Variable markings -------------------------------------------------------*/
+
+/**
+ *  @brief  Global Variable marking
+ *
+ *  Variables marked with "global" are to be considered globally accessible.
+ */
+#define global
+
+#endif /* DOC_MARKUP_H_ */

--- a/sampler.c
+++ b/sampler.c
@@ -1,0 +1,168 @@
+/*- Header files ------------------------------------------------------------*/
+#include <assert.h>                 /* Libc Assertions                       */
+#include <stdbool.h>                /* Libc Standard boolean                 */
+#include <stdint.h>                 /* Libc Standard integer                 */
+#include <string.h>                 /* Libc String functions (Memset)        */
+#include "tm4c1294ncpdt.h"          /* TivaWare Register Map                 */
+#include "inc/hw_memmap.h"          /* TivaWare Memory Map                   */
+#include "driverlib/gpio.h"         /* TivaWare GPIO DriverLib               */
+#include "driverlib/pin_map.h"      /* TivaWare GPIO Pin Mapping             */
+#include "driverlib/adc.h"          /* TivaWare ADC DriverLib                */
+#include "driverlib/timer.h"        /* TivaWare GPTM DriverLib               */
+#include "driverlib/sysctl.h"       /* TivaWare SysCtl DriverLib             */
+#include "driverlib/interrupt.h"    /* TivaWare Interrupt Library            */
+#include "adc.h"                    /* ADC Module                            */
+#include "sampler.h"
+
+#define ADC_INT_TIMING 1
+
+/*- Macros ------------------------------------------------------------------*/
+#define IS_SAMPLER_TIMEBASE(x)  ((x)>0x00 && (x)<EN_SAMPLER_TIMEBASE_MAX)
+#define IS_SAMPLER_TRIGSRC(x)   (((x) == EN_SAMPLER_TRIGSRC_DISABLE)    ||    \
+                                 ((x) == EN_SAMPLER_TRIGSRC_CONTINUOUS) ||    \
+                                 ((x) == EN_SAMPLER_TRIGSRC_COMPARATOR) ||    \
+                                 ((x) == EN_SAMPLER_TRIGSRC_EXTERNAL))
+#define IS_SAMPLER_TRIGMODE(x)  (((x) == EN_SAMPLER_TRIGMODE_STOP)     ||     \
+                                 ((x) == EN_SAMPLER_TRIGMODE_SINGLE)   ||     \
+                                 ((x) == EN_SAMPLER_TRIGMODE_NORMAL))
+
+
+/*- Global variables --------------------------------------------------------*/
+global int16_t g_aiSampleBuffer[SAMPLER_BUF_LEN] = {[0 ... SAMPLER_BUF_LEN-1] = SAMPLER_SAMPLE_INVALID};
+
+
+/*- Inline functions --------------------------------------------------------*/
+/**
+ *  @brief Clear sample buffer and reset each position to "invalid" value
+ *                                                                           */
+static inline void vSamplerClearBuffer(int16_t* p_aiBuffer)
+{
+    memset(p_aiBuffer, SAMPLER_SAMPLE_INVALID, SAMPLER_BUF_LEN * sizeof(*p_aiBuffer));
+}
+
+
+/*- Local prototypes --------------------------------------------------------*/
+static void vSamplerStop(void);
+static void vSamplerStartTimer(void);
+
+
+/**
+ *  @brief  Initialise the sampler module
+ *
+ *  Configures GPT1 as potential ADC trigger, and GPIO pin PE
+ *                                                                           */
+void vSamplerInit(void)
+{
+    /* Setup GPIO Port K Run Mode Clock                                      */
+    SysCtlPeripheralEnable(SAMPLER_EXT_RCGC);
+    /* Setup GPTM Timer 1 Run Mode Clock                                     */
+    SysCtlPeripheralEnable(SYSCTL_PERIPH_TIMER1);
+    asm("\tnop;\r\n\tnop;\r\n\tnop;\r\n");
+
+    /* Prepare PK7 as trigger input                                          */
+    /* not yet implemented                                                   */
+
+    /* Prepare GPT1 as ADC trigger                                           */
+    TimerClockSourceSet(TIMER1_BASE, TIMER_CLOCK_SYSTEM);
+    TimerConfigure(TIMER1_BASE, TIMER_CFG_PERIODIC);
+    TimerPrescaleSet(TIMER1_BASE, TIMER_BOTH, 0);
+    TimerMatchSet(TIMER1_BASE, TIMER_BOTH, 0);
+    TimerLoadSet(TIMER1_BASE, TIMER_BOTH, EN_SAMPLER_TIMEBASE_1ms);
+    TimerControlTrigger(TIMER1_BASE, TIMER_BOTH, true);
+
+    /* Configure ADC Sample 0 (Vin) complete interrupt                       */
+    IntEnable(INT_ADC0SS0);
+}
+
+/**
+ *  @brief  Reconfigure Timer ILR value for selected timebase
+ *
+ *  @param[in]  eTimebase   Selected timebase
+ *                                                                           */
+void vSetSamplerTimebase(teSamplerTimebase eTimebase)
+{
+    assert(IS_SAMPLER_TIMEBASE(eTimebase));
+
+    TimerLoadSet(TIMER1_BASE, TIMER_BOTH, (uint32_t)eTimebase);
+}
+
+/**
+ *  @brief  Configure Sampler trigger setup
+ *
+ *  @param[in]  eTriggerSource  Trigger source
+ *  @param[in]  eTriggerMode    Trigger mode
+ *                                                                           */
+void vSetSamplerTrigger(teSamplerTrigSrc eTriggerSource, teSamplerTrigMode eTriggerMode)
+{
+    assert(IS_SAMPLER_TRIGSRC(eTriggerSource));
+    assert(IS_SAMPLER_TRIGMODE(eTriggerMode));
+
+    switch (eTriggerSource)
+    {
+    case EN_SAMPLER_TRIGSRC_CONTINUOUS:
+        /* Configure continuous triggering from timer                        */
+        if (eTriggerMode == EN_SAMPLER_TRIGMODE_STOP)
+        {
+            vSamplerStop();
+        }
+        else
+        {
+            vSamplerStartTimer();
+        }
+        break;
+    case EN_SAMPLER_TRIGSRC_COMPARATOR:
+        /* Not yet implemented                                               */
+        assert(false);
+    case EN_SAMPLER_TRIGSRC_EXTERNAL:
+        /* Not yet implemented                                               */
+        assert(false);
+    case EN_SAMPLER_TRIGSRC_DISABLE:
+    default:
+        vSamplerStop();
+    }
+}
+
+/**
+ *  @brief  Stop sample timer and reconfigure ADC sequencer for SSn-bit trig.
+ *                                                                           */
+void vSamplerStop(void)
+{
+    /* Disable ADC Sequence Complete Interrupt                               */
+    ADCIntDisable(ADC0_BASE, ADC_SEQ_VIN);
+    /* Reset ADC trigger to SS0-bit in PSSI register                         */
+    ADCSequenceDisable(ADC0_BASE, ADC_SEQ_VIN);
+    ADCSequenceConfigure(ADC0_BASE, ADC_SEQ_VIN, ADC_TRIGGER_PROCESSOR, 0);
+    ADCSequenceEnable(ADC0_BASE, ADC_SEQ_VIN);
+    /* Disable running timer                                                 */
+    TimerDisable(TIMER1_BASE, TIMER_BOTH);
+}
+
+/**
+ *  @brief  Configure ADC sequencer to trigger from Timer 1
+ *                                                                           */
+static void vSamplerStartTimer(void)
+{
+    /* Clear Sample bufffer                                                  */
+    vSamplerClearBuffer(g_aiSampleBuffer);
+    /* Enable timer                                                          */
+    TimerEnable(TIMER1_BASE, TIMER_BOTH);
+    /* Configure ADC sequencer to trigger from timer                         */
+    ADCSequenceDisable(ADC0_BASE, ADC_SEQ_VIN);
+    ADCSequenceConfigure(ADC0_BASE, ADC_SEQ_VIN, ADC_TRIGGER_TIMER, 0);
+    ADCSequenceEnable(ADC0_BASE, ADC_SEQ_VIN);
+    /* Enable ADC Sequence Complete interrupt                                */
+    ADCIntEnable(ADC0_BASE, ADC_SEQ_VIN);
+}
+
+/**
+ *  ADC Sample Complete interrupt service routine
+ *                                                                           */
+void __attribute__((interrupt)) vISR_AdcVinSequencer(void)
+{
+    ADCIntClear(ADC0_BASE, ADC_SEQ_VIN);
+
+    /* Not yet implemented                                                   */
+    ;
+
+    g_aiSampleBuffer[0] = ADC0_SSFIFO0_R;
+}

--- a/sampler.h
+++ b/sampler.h
@@ -1,0 +1,77 @@
+#ifndef SAMPLER_H_
+#define SAMPLER_H_
+
+/*- Header files ------------------------------------------------------------*/
+#include <stdint.h>                 /* Libc Standard integer                 */
+#include "doc_markup.h"             /* Documentation markup defines          */
+
+
+/*- Defines -----------------------------------------------------------------*/
+#define SAMPLER_EXT_RCGC    SYSCTL_PERIPH_GPIOK /* External Trig GPIO Periph */
+#define SAMPLER_EXT_PORT    GPIO_PORTK_BASE     /* External Trig GPIO Port   */
+#define SAMPLER_EXT_PIN     7                   /* External Trig GPIO Pin    */
+
+#define SAMPLER_BUF_LEN     480     /* Number of samples to be stored        */
+#define SAMPLER_SAMPLE_INVALID (-1) /* Do not draw this sample               */
+
+                                    /* Screen redraw / Pixel draw threshold  */
+#define SAMPLER_SLOW_THR    EN_SAMPLER_TIMEBASE_100ms
+
+
+
+/*- Global variables --------------------------------------------------------*/
+extern global int16_t g_aiSampleBuffer[SAMPLER_BUF_LEN]; /* Sample buffer    */
+
+
+/*- Type definitions --------------------------------------------------------*/
+typedef enum tag_teSampleTrigSrc {
+    /*! Disable triggering          */
+    EN_SAMPLER_TRIGSRC_DISABLE,
+
+    /*! Untriggered timer sampling  */
+    EN_SAMPLER_TRIGSRC_CONTINUOUS,
+
+    /*! Analog comparator as source */
+    EN_SAMPLER_TRIGSRC_COMPARATOR,
+
+    /*! Digital input as source     */
+    EN_SAMPLER_TRIGSRC_EXTERNAL
+} teSamplerTrigSrc;
+
+typedef enum tag_teSamplerTrigMode {
+    /*! Stop triggering             */
+    EN_SAMPLER_TRIGMODE_STOP,
+
+    /*! Single capture (480 sampl.) */
+    EN_SAMPLER_TRIGMODE_SINGLE,
+
+    /*! Re-Arm after 480 samples    */
+    EN_SAMPLER_TRIGMODE_NORMAL
+} teSamplerTrigMode;
+
+typedef enum tag_teSamplerTimebase {
+    EN_SAMPLER_TIMEBASE_100us = 300,
+    EN_SAMPLER_TIMEBASE_200us = 600,
+    EN_SAMPLER_TIMEBASE_500us = 1500,
+    EN_SAMPLER_TIMEBASE_1ms = 3000,
+    EN_SAMPLER_TIMEBASE_2ms = 6000,
+    EN_SAMPLER_TIMEBASE_5ms = 15000,
+    EN_SAMPLER_TIMEBASE_10ms = 30000,
+    EN_SAMPLER_TIMEBASE_20ms = 60000,
+    EN_SAMPLER_TIMEBASE_50ms = 150000,
+    EN_SAMPLER_TIMEBASE_100ms = 300000,
+    EN_SAMPLER_TIMEBASE_200ms = 600000,
+    EN_SAMPLER_TIMEBASE_500ms = 1500000,
+    EN_SAMPLER_TIMEBASE_1s = 3000000,
+    EN_SAMPLER_TIMEBASE_2s = 6000000,
+    EN_SAMPLER_TIMEBASE_5s = 15000000,
+    EN_SAMPLER_TIMEBASE_MAX = 0xFFFFFFFF
+} teSamplerTimebase;
+
+
+/*- Prototypes --------------------------------------------------------------*/
+void vSamplerInit(void);
+void vSetSamplerTimebase(teSamplerTimebase eTimebase);
+void vSetSamplerTrigger(teSamplerTrigSrc eTriggerSource, teSamplerTrigMode eTriggerMode);
+
+#endif /* SAMPLER_H_ */


### PR DESCRIPTION
This PR contains the following modifications:
- Add ADC configuration and access functions
- Add Sampler to automate ADC trigger setup
- Replaces the Touch test program with an ADC demo

**Note regarding Interrupt usage**
The sampler module is currently using the `ADC0SS0` interrupt to store ADC samples into the global sample buffer. Future implementations should use µDMA for this task.

**Note regarding IVT entries**
Interrupt Vector Table changes are supplies as a ".patch"-file. Apply this patch to the IVT source file using `patch <IVT source file> IVT.patch` from within Git Shell